### PR TITLE
Backend database foundation

### DIFF
--- a/Backend/drizzle/0000_happy_vargas.sql
+++ b/Backend/drizzle/0000_happy_vargas.sql
@@ -1,0 +1,50 @@
+CREATE TABLE `book_classification_tags` (
+	`book_id` text NOT NULL,
+	`classification_tag_id` text NOT NULL,
+	`created_at` text NOT NULL,
+	FOREIGN KEY (`book_id`) REFERENCES `books`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`classification_tag_id`) REFERENCES `classification_tags`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `book_classification_tags_book_tag_idx` ON `book_classification_tags` (`book_id`,`classification_tag_id`);--> statement-breakpoint
+CREATE TABLE `books` (
+	`id` text PRIMARY KEY NOT NULL,
+	`title` text NOT NULL,
+	`author` text,
+	`publisher` text,
+	`published_date` text,
+	`isbn` text,
+	`book_barcode` text,
+	`management_barcode` text,
+	`external_source` text,
+	`external_id` text,
+	`location_id` text,
+	`management_memo` text,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`location_id`) REFERENCES `locations`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `books_management_barcode_idx` ON `books` (`management_barcode`);--> statement-breakpoint
+CREATE TABLE `classification_tags` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`source` text NOT NULL,
+	`is_active` integer DEFAULT true NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `classification_tags_name_idx` ON `classification_tags` (`name`);--> statement-breakpoint
+CREATE TABLE `locations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`sort_order` integer DEFAULT 0 NOT NULL,
+	`is_active` integer DEFAULT true NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `locations_name_idx` ON `locations` (`name`);

--- a/Backend/drizzle/meta/0000_snapshot.json
+++ b/Backend/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,352 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "85470659-1b3a-460f-aa0c-5b94c1ad7a00",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "book_classification_tags": {
+      "name": "book_classification_tags",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "classification_tag_id": {
+          "name": "classification_tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "book_classification_tags_book_tag_idx": {
+          "name": "book_classification_tags_book_tag_idx",
+          "columns": [
+            "book_id",
+            "classification_tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "book_classification_tags_book_id_books_id_fk": {
+          "name": "book_classification_tags_book_id_books_id_fk",
+          "tableFrom": "book_classification_tags",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "book_classification_tags_classification_tag_id_classification_tags_id_fk": {
+          "name": "book_classification_tags_classification_tag_id_classification_tags_id_fk",
+          "tableFrom": "book_classification_tags",
+          "tableTo": "classification_tags",
+          "columnsFrom": [
+            "classification_tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "books": {
+      "name": "books",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_date": {
+          "name": "published_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isbn": {
+          "name": "isbn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "book_barcode": {
+          "name": "book_barcode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "management_barcode": {
+          "name": "management_barcode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "management_memo": {
+          "name": "management_memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "books_management_barcode_idx": {
+          "name": "books_management_barcode_idx",
+          "columns": [
+            "management_barcode"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "books_location_id_locations_id_fk": {
+          "name": "books_location_id_locations_id_fk",
+          "tableFrom": "books",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "classification_tags": {
+      "name": "classification_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "classification_tags_name_idx": {
+          "name": "classification_tags_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "locations_name_idx": {
+          "name": "locations_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/Backend/drizzle/meta/_journal.json
+++ b/Backend/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1777194053402,
+      "tag": "0000_happy_vargas",
+      "breakpoints": true
+    }
+  ]
+}

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/server.ts",
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.build.json",
     "start": "node dist/server.js",
     "test": "vitest run --passWithNoTests",
     "lint": "tsc --noEmit",

--- a/Backend/src/app.test.ts
+++ b/Backend/src/app.test.ts
@@ -1,0 +1,87 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createApp } from "./app.js";
+import type { AppConfig } from "./config/env.js";
+import { createDatabaseClient, type DatabaseClient } from "./db/client.js";
+import { runMigrations } from "./db/migrate.js";
+
+describe("backend application foundation", () => {
+  let database: DatabaseClient;
+  let config: AppConfig;
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "book-manager-"));
+
+    config = {
+      port: 0,
+      corsOrigin: "http://localhost:3000",
+      databasePath: join(tempDir, "test.sqlite")
+    };
+
+    database = createDatabaseClient(config);
+    runMigrations(database);
+  });
+
+  afterEach(() => {
+    database?.sqlite.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("applies migrations to a fresh SQLite database", () => {
+    const tables = database.sqlite
+      .prepare(
+        "select name from sqlite_master where type = 'table' and name in (?, ?, ?, ?) order by name"
+      )
+      .all("books", "locations", "classification_tags", "book_classification_tags");
+
+    expect(tables).toEqual([
+      { name: "book_classification_tags" },
+      { name: "books" },
+      { name: "classification_tags" },
+      { name: "locations" }
+    ]);
+  });
+
+  it("reports application and database health", async () => {
+    const app = await createApp({ config, database, logger: false });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/health"
+    });
+
+    await app.close();
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      ok: true,
+      service: "book-manager-backend",
+      database: "ok"
+    });
+  });
+
+  it("returns the shared validation error response shape", async () => {
+    const app = await createApp({ config, database, logger: false });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/books/lookup",
+      payload: {}
+    });
+
+    await app.close();
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({
+      message: "Validation failed",
+      errors: [
+        {
+          field: "bookBarcode"
+        }
+      ]
+    });
+  });
+});

--- a/Backend/src/app.ts
+++ b/Backend/src/app.ts
@@ -1,0 +1,30 @@
+import cors from "@fastify/cors";
+import Fastify from "fastify";
+import type { AppConfig } from "./config/env.js";
+import type { DatabaseClient } from "./db/client.js";
+import { registerErrorHandler } from "./errors.js";
+import { registerBookRoutes } from "./routes/books.js";
+import { registerHealthRoutes } from "./routes/health.js";
+
+export type CreateAppOptions = {
+  config: AppConfig;
+  database: DatabaseClient;
+  logger?: boolean;
+};
+
+export async function createApp({ config, database, logger = true }: CreateAppOptions) {
+  const app = Fastify({
+    logger
+  });
+
+  registerErrorHandler(app);
+
+  await app.register(cors, {
+    origin: config.corsOrigin
+  });
+
+  await app.register(registerHealthRoutes, { database });
+  await app.register(registerBookRoutes, { config });
+
+  return app;
+}

--- a/Backend/src/db/client.ts
+++ b/Backend/src/db/client.ts
@@ -2,11 +2,19 @@ import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
-import { loadConfig } from "../config/env.js";
+import type { AppConfig } from "../config/env.js";
+import * as schema from "./schema.js";
 
-const config = loadConfig();
+export type DatabaseClient = ReturnType<typeof createDatabaseClient>;
 
-mkdirSync(dirname(config.databasePath), { recursive: true });
+export function createDatabaseClient(config: Pick<AppConfig, "databasePath">) {
+  mkdirSync(dirname(config.databasePath), { recursive: true });
 
-export const sqlite = new Database(config.databasePath);
-export const db = drizzle(sqlite);
+  const sqlite = new Database(config.databasePath);
+  sqlite.pragma("foreign_keys = ON");
+
+  return {
+    sqlite,
+    db: drizzle(sqlite, { schema })
+  };
+}

--- a/Backend/src/db/migrate.ts
+++ b/Backend/src/db/migrate.ts
@@ -1,0 +1,16 @@
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import type { DatabaseClient } from "./client.js";
+
+export function getMigrationsFolder() {
+  return resolve(process.cwd(), "drizzle");
+}
+
+export function runMigrations(client: DatabaseClient, migrationsFolder = getMigrationsFolder()) {
+  if (!existsSync(migrationsFolder)) {
+    throw new Error(`Migrations folder was not found: ${migrationsFolder}`);
+  }
+
+  migrate(client.db, { migrationsFolder });
+}

--- a/Backend/src/errors.ts
+++ b/Backend/src/errors.ts
@@ -1,0 +1,35 @@
+import type { FastifyInstance } from "fastify";
+import { ZodError } from "zod";
+
+export type ApiFieldError = {
+  field: string;
+  message: string;
+};
+
+export function validationError(errors: ApiFieldError[]) {
+  return {
+    message: "Validation failed",
+    errors
+  };
+}
+
+export function registerErrorHandler(app: FastifyInstance) {
+  app.setErrorHandler((error, _request, reply) => {
+    if (error instanceof ZodError) {
+      return reply.status(400).send(
+        validationError(
+          error.issues.map((issue) => ({
+            field: issue.path.join("."),
+            message: issue.message
+          }))
+        )
+      );
+    }
+
+    app.log.error(error);
+
+    return reply.status(500).send({
+      message: "Internal server error"
+    });
+  });
+}

--- a/Backend/src/routes/books.ts
+++ b/Backend/src/routes/books.ts
@@ -1,25 +1,29 @@
 import type { FastifyInstance } from "fastify";
-import { loadConfig } from "../config/env.js";
+import type { AppConfig } from "../config/env.js";
+import { validationError } from "../errors.js";
 import { bookLookupRequestSchema } from "../schemas/books.js";
 import { lookupBookByIsbn } from "../services/openLibrary.js";
 
-export async function registerBookRoutes(app: FastifyInstance) {
-  const config = loadConfig();
+export type BookRouteOptions = {
+  config: AppConfig;
+};
 
+export async function registerBookRoutes(app: FastifyInstance, options: BookRouteOptions) {
   app.post("/api/books/lookup", async (request, reply) => {
     const parsed = bookLookupRequestSchema.safeParse(request.body);
 
     if (!parsed.success) {
-      return reply.status(400).send({
-        message: "Validation failed",
-        errors: parsed.error.issues.map((issue) => ({
-          field: issue.path.join("."),
-          message: issue.message
-        }))
-      });
+      return reply.status(400).send(
+        validationError(
+          parsed.error.issues.map((issue) => ({
+            field: issue.path.join("."),
+            message: issue.message
+          }))
+        )
+      );
     }
 
-    const result = await lookupBookByIsbn(parsed.data.bookBarcode, config);
+    const result = await lookupBookByIsbn(parsed.data.bookBarcode, options.config);
 
     if (!result) {
       return reply.status(404).send({

--- a/Backend/src/routes/health.ts
+++ b/Backend/src/routes/health.ts
@@ -1,10 +1,19 @@
 import type { FastifyInstance } from "fastify";
+import { sql } from "drizzle-orm";
+import type { DatabaseClient } from "../db/client.js";
 
-export async function registerHealthRoutes(app: FastifyInstance) {
+export type HealthRouteOptions = {
+  database: DatabaseClient;
+};
+
+export async function registerHealthRoutes(app: FastifyInstance, options: HealthRouteOptions) {
   app.get("/api/health", async () => {
+    options.database.db.run(sql`select 1`);
+
     return {
       ok: true,
-      service: "book-manager-backend"
+      service: "book-manager-backend",
+      database: "ok"
     };
   });
 }

--- a/Backend/src/server.ts
+++ b/Backend/src/server.ts
@@ -1,22 +1,15 @@
 import "dotenv/config";
-import cors from "@fastify/cors";
-import Fastify from "fastify";
+import { createApp } from "./app.js";
 import { loadConfig } from "./config/env.js";
-import { registerBookRoutes } from "./routes/books.js";
-import { registerHealthRoutes } from "./routes/health.js";
+import { createDatabaseClient } from "./db/client.js";
+import { runMigrations } from "./db/migrate.js";
 
 const config = loadConfig();
+const database = createDatabaseClient(config);
 
-const app = Fastify({
-  logger: true
-});
+runMigrations(database);
 
-await app.register(cors, {
-  origin: config.corsOrigin
-});
-
-await app.register(registerHealthRoutes);
-await app.register(registerBookRoutes);
+const app = await createApp({ config, database });
 
 try {
   await app.listen({

--- a/Backend/tsconfig.build.json
+++ b/Backend/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"]
+}

--- a/Docs/development.md
+++ b/Docs/development.md
@@ -36,6 +36,22 @@ docker compose up
 
 Docker Composeでは `./data:/data` をマウントします。通常のバックアップは、ホスト側の `data/book-manager.sqlite` を保存する運用を基本とします。
 
+## DB Migration
+
+Backendは起動時にDrizzle migrationを適用します。migrationファイルは `Backend/drizzle/` に管理します。
+
+Schemaを変更した場合は、以下でmigrationを生成します。
+
+```powershell
+pnpm --filter @book-manager/backend db:generate
+```
+
+手動でmigrationを適用する場合は、`DATABASE_PATH` を指定して以下を実行します。
+
+```powershell
+pnpm --filter @book-manager/backend db:migrate
+```
+
 ## 環境変数
 
 | 名前 | 必須 | 説明 |


### PR DESCRIPTION
## Summary
- Add Drizzle initial migration for MVP tables
- Refactor backend startup into createApp with injectable database client
- Run migrations on backend startup and check DB health in /api/health
- Add shared API error response helper and foundation tests
- Document migration workflow in Docs/development.md

## Verification
- mise run typecheck
- mise run lint
- mise run test
- mise run build
- docker compose --env-file .env.example config

Refs #4