### PR TITLE
Frontend routing and layout foundation

### DIFF
--- a/Frontend/src/App.tsx
+++ b/Frontend/src/App.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from "react";
+import { getApiBaseUrl, getHealth, type ApiError, type HealthResponse } from "./api/client.js";
+import { AppLayout } from "./components/AppLayout.js";
+import { ErrorState, LoadingState } from "./components/StateBlocks.js";
+import { BookDetailPage } from "./pages/BookDetailPage.js";
+import { BookFormPage } from "./pages/BookFormPage.js";
+import { BooksPage } from "./pages/BooksPage.js";
+import { ClassificationTagsPage } from "./pages/ClassificationTagsPage.js";
+import { DataPage } from "./pages/DataPage.js";
+import { LocationsPage } from "./pages/LocationsPage.js";
+import { NotFoundPage } from "./pages/NotFoundPage.js";
+import { resolveRoute, type Route } from "./router.js";
+
+export function App() {
+  const [currentPath, setCurrentPath] = useState(window.location.pathname);
+  const [health, setHealth] = useState<HealthResponse | null>(null);
+  const [healthError, setHealthError] = useState<ApiError | null>(null);
+  const [isHealthLoading, setIsHealthLoading] = useState(true);
+
+  useEffect(() => {
+    function handlePopState() {
+      setCurrentPath(window.location.pathname);
+    }
+
+    if (window.location.pathname === "/") {
+      window.history.replaceState({}, "", "/books");
+      setCurrentPath("/books");
+    }
+
+    window.addEventListener("popstate", handlePopState);
+
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, []);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadHealth() {
+      setIsHealthLoading(true);
+
+      try {
+        const result = await getHealth();
+
+        if (isMounted) {
+          setHealth(result);
+          setHealthError(null);
+        }
+      } catch (error) {
+        if (isMounted) {
+          setHealth(null);
+          setHealthError(error as ApiError);
+        }
+      } finally {
+        if (isMounted) {
+          setIsHealthLoading(false);
+        }
+      }
+    }
+
+    void loadHealth();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const route = resolveRoute(currentPath);
+
+  return (
+    <AppLayout currentPath={currentPath}>
+      <section className="overview-card">
+        <div>
+          <p className="eyebrow">Backend API</p>
+          <code>{getApiBaseUrl()}</code>
+        </div>
+        <HealthBadge error={healthError} health={health} isLoading={isHealthLoading} />
+      </section>
+      {renderRoute(route)}
+    </AppLayout>
+  );
+}
+
+function renderRoute(route: Route) {
+  switch (route.name) {
+    case "books":
+      return <BooksPage />;
+    case "bookNew":
+      return <BookFormPage mode="create" />;
+    case "bookDetail":
+      return <BookDetailPage bookId={route.id} />;
+    case "bookEdit":
+      return <BookFormPage bookId={route.id} mode="edit" />;
+    case "locations":
+      return <LocationsPage />;
+    case "classificationTags":
+      return <ClassificationTagsPage />;
+    case "data":
+      return <DataPage />;
+    case "notFound":
+      return <NotFoundPage />;
+  }
+}
+
+type HealthBadgeProps = {
+  error: ApiError | null;
+  health: HealthResponse | null;
+  isLoading: boolean;
+};
+
+function HealthBadge({ error, health, isLoading }: HealthBadgeProps) {
+  if (isLoading) {
+    return <LoadingState title="API確認中" />;
+  }
+
+  if (error) {
+    return <ErrorState title="API未接続">{error.message}</ErrorState>;
+  }
+
+  return (
+    <div className="health-badge">
+      <span className="status-dot" />
+      <div>
+        <strong>{health?.service ?? "backend"}</strong>
+        <span>DB: {health?.database ?? "unknown"}</span>
+      </div>
+    </div>
+  );
+}

--- a/Frontend/src/api/client.ts
+++ b/Frontend/src/api/client.ts
@@ -1,0 +1,50 @@
+export type ApiError = {
+  message: string;
+  status: number;
+  errors?: Array<{
+    field: string;
+    message: string;
+  }>;
+};
+
+export type HealthResponse = {
+  ok: boolean;
+  service: string;
+  database?: string;
+};
+
+const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL ?? "").replace(/\/$/, "");
+
+export function getApiBaseUrl() {
+  return apiBaseUrl || "/api";
+}
+
+export async function apiRequest<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${apiBaseUrl}${path}`, {
+    headers: {
+      "Content-Type": "application/json",
+      ...init?.headers
+    },
+    ...init
+  });
+
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => null)) as Partial<ApiError> | null;
+
+    throw {
+      message: payload?.message ?? `Request failed with status ${response.status}`,
+      status: response.status,
+      errors: payload?.errors
+    } satisfies ApiError;
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return (await response.json()) as T;
+}
+
+export function getHealth() {
+  return apiRequest<HealthResponse>("/api/health");
+}

--- a/Frontend/src/components/AppLayout.tsx
+++ b/Frontend/src/components/AppLayout.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from "react";
+import { Link } from "./Link.js";
+
+type AppLayoutProps = {
+  children: ReactNode;
+  currentPath: string;
+};
+
+const navigationItems = [
+  { href: "/books", label: "本一覧" },
+  { href: "/books/new", label: "本登録" },
+  { href: "/locations", label: "保管場所" },
+  { href: "/classification-tags", label: "分類タグ" },
+  { href: "/data", label: "入出力" }
+];
+
+export function AppLayout({ children, currentPath }: AppLayoutProps) {
+  return (
+    <div className="app-shell">
+      <aside className="sidebar" aria-label="メインナビゲーション">
+        <div className="brand">
+          <span className="brand-mark">BM</span>
+          <div>
+            <p className="eyebrow">Book Manager</p>
+            <h1>蔵書管理</h1>
+          </div>
+        </div>
+        <nav className="nav-list">
+          {navigationItems.map((item) => (
+            <Link
+              className={isActive(currentPath, item.href) ? "nav-link active" : "nav-link"}
+              href={item.href}
+              key={item.href}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+      </aside>
+      <main className="content-shell">{children}</main>
+    </div>
+  );
+}
+
+function isActive(currentPath: string, href: string) {
+  if (href === "/books") {
+    return currentPath === "/books" || currentPath.startsWith("/books/");
+  }
+
+  return currentPath === href || currentPath.startsWith(`${href}/`);
+}

--- a/Frontend/src/components/Link.tsx
+++ b/Frontend/src/components/Link.tsx
@@ -1,0 +1,33 @@
+import type { AnchorHTMLAttributes, MouseEvent, ReactNode } from "react";
+import { navigateTo } from "../router.js";
+
+type LinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
+  children: ReactNode;
+  href: string;
+};
+
+export function Link({ children, href, onClick, ...props }: LinkProps) {
+  function handleClick(event: MouseEvent<HTMLAnchorElement>) {
+    onClick?.(event);
+
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.shiftKey
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    navigateTo(href);
+  }
+
+  return (
+    <a href={href} onClick={handleClick} {...props}>
+      {children}
+    </a>
+  );
+}

--- a/Frontend/src/components/StateBlocks.tsx
+++ b/Frontend/src/components/StateBlocks.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+
+type StateBlockProps = {
+  title: string;
+  children: ReactNode;
+};
+
+export function EmptyState({ title, children }: StateBlockProps) {
+  return (
+    <section className="state-block empty-state">
+      <h2>{title}</h2>
+      <p>{children}</p>
+    </section>
+  );
+}
+
+export function ErrorState({ title, children }: StateBlockProps) {
+  return (
+    <section className="state-block error-state" role="alert">
+      <h2>{title}</h2>
+      <p>{children}</p>
+    </section>
+  );
+}
+
+export function LoadingState({ title = "読み込み中" }: Partial<StateBlockProps>) {
+  return (
+    <section className="state-block loading-state" aria-live="polite">
+      <span className="loading-dot" />
+      <h2>{title}</h2>
+    </section>
+  );
+}

--- a/Frontend/src/main.tsx
+++ b/Frontend/src/main.tsx
@@ -1,27 +1,7 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
+import { App } from "./App.js";
 import "./styles.css";
-
-const apiBaseUrl = import.meta.env.VITE_API_BASE_URL ?? "";
-
-function App() {
-  return (
-    <main className="shell">
-      <section className="hero">
-        <p className="eyebrow">Book Manager</p>
-        <h1>自宅や研究室の蔵書を、バーコードと保管場所で管理する。</h1>
-        <p className="lead">
-          MVPでは本の登録、検索、保管場所タグ、分類タグ、Export/Import、
-          Open LibraryのISBN照会を実装していきます。
-        </p>
-        <div className="panel">
-          <span>Backend API</span>
-          <code>{apiBaseUrl || "/api"}</code>
-        </div>
-      </section>
-    </main>
-  );
-}
 
 const root = document.getElementById("root");
 

--- a/Frontend/src/pages/BookDetailPage.tsx
+++ b/Frontend/src/pages/BookDetailPage.tsx
@@ -1,0 +1,20 @@
+import { Link } from "../components/Link.js";
+
+type BookDetailPageProps = {
+  bookId: string;
+};
+
+export function BookDetailPage({ bookId }: BookDetailPageProps) {
+  return (
+    <section className="page-panel">
+      <div className="page-heading">
+        <p className="eyebrow">Book Detail</p>
+        <h2>本詳細</h2>
+        <p>対象ID: {bookId} の詳細情報、削除確認、編集導線を表示する画面にします。</p>
+      </div>
+      <Link className="primary-action" href={`/books/${bookId}/edit`}>
+        編集画面へ
+      </Link>
+    </section>
+  );
+}

--- a/Frontend/src/pages/BookFormPage.tsx
+++ b/Frontend/src/pages/BookFormPage.tsx
@@ -1,0 +1,27 @@
+type BookFormPageProps = {
+  mode: "create" | "edit";
+  bookId?: string;
+};
+
+export function BookFormPage({ mode, bookId }: BookFormPageProps) {
+  const isEdit = mode === "edit";
+
+  return (
+    <section className="page-panel">
+      <div className="page-heading">
+        <p className="eyebrow">{isEdit ? "Edit Book" : "New Book"}</p>
+        <h2>{isEdit ? "本編集" : "本登録"}</h2>
+        <p>
+          {isEdit
+            ? `対象ID: ${bookId} の登録情報を編集する画面にします。`
+            : "本のバーコード照会、管理用バーコード、保管場所、分類タグを入力する画面にします。"}
+        </p>
+      </div>
+      <div className="placeholder-grid">
+        <div>書誌情報フォーム</div>
+        <div>バーコード入力</div>
+        <div>分類タグ候補</div>
+      </div>
+    </section>
+  );
+}

--- a/Frontend/src/pages/BooksPage.tsx
+++ b/Frontend/src/pages/BooksPage.tsx
@@ -1,0 +1,20 @@
+import { Link } from "../components/Link.js";
+import { EmptyState } from "../components/StateBlocks.js";
+
+export function BooksPage() {
+  return (
+    <section className="page-panel">
+      <div className="page-heading">
+        <p className="eyebrow">Books</p>
+        <h2>本一覧</h2>
+        <p>タイトル、著者、ISBN、本のバーコード、管理用バーコードで検索できる画面にします。</p>
+      </div>
+      <EmptyState title="まだ本一覧UIは未実装です">
+        次の画面実装Issueで、検索、保管場所絞り込み、分類タグ絞り込み、詳細導線を追加します。
+      </EmptyState>
+      <Link className="primary-action" href="/books/new">
+        本登録画面へ
+      </Link>
+    </section>
+  );
+}

--- a/Frontend/src/pages/ClassificationTagsPage.tsx
+++ b/Frontend/src/pages/ClassificationTagsPage.tsx
@@ -1,0 +1,15 @@
+export function ClassificationTagsPage() {
+  return (
+    <section className="page-panel">
+      <div className="page-heading">
+        <p className="eyebrow">Classification Tags</p>
+        <h2>分類タグ管理</h2>
+        <p>手入力タグとOpen Library subject由来タグを管理する画面にします。</p>
+      </div>
+      <div className="placeholder-grid">
+        <div>分類タグ一覧</div>
+        <div>登録フォーム</div>
+      </div>
+    </section>
+  );
+}

--- a/Frontend/src/pages/DataPage.tsx
+++ b/Frontend/src/pages/DataPage.tsx
@@ -1,0 +1,16 @@
+export function DataPage() {
+  return (
+    <section className="page-panel">
+      <div className="page-heading">
+        <p className="eyebrow">Data</p>
+        <h2>データ入出力</h2>
+        <p>JSON Export/Import、Importプレビュー、重複時の上書き/無視選択を扱う画面にします。</p>
+      </div>
+      <div className="placeholder-grid">
+        <div>Export</div>
+        <div>Import Preview</div>
+        <div>Conflict Resolution</div>
+      </div>
+    </section>
+  );
+}

--- a/Frontend/src/pages/LocationsPage.tsx
+++ b/Frontend/src/pages/LocationsPage.tsx
@@ -1,0 +1,15 @@
+export function LocationsPage() {
+  return (
+    <section className="page-panel">
+      <div className="page-heading">
+        <p className="eyebrow">Locations</p>
+        <h2>保管場所管理</h2>
+        <p>保管場所タグの登録、編集、無効化を行う画面にします。</p>
+      </div>
+      <div className="placeholder-grid">
+        <div>保管場所一覧</div>
+        <div>登録フォーム</div>
+      </div>
+    </section>
+  );
+}

--- a/Frontend/src/pages/NotFoundPage.tsx
+++ b/Frontend/src/pages/NotFoundPage.tsx
@@ -1,0 +1,16 @@
+import { Link } from "../components/Link.js";
+
+export function NotFoundPage() {
+  return (
+    <section className="page-panel">
+      <div className="page-heading">
+        <p className="eyebrow">404</p>
+        <h2>画面が見つかりません</h2>
+        <p>指定されたURLに対応する画面はまだありません。</p>
+      </div>
+      <Link className="primary-action" href="/books">
+        本一覧へ戻る
+      </Link>
+    </section>
+  );
+}

--- a/Frontend/src/router.test.ts
+++ b/Frontend/src/router.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { resolveRoute } from "./router.js";
+
+describe("resolveRoute", () => {
+  it("maps MVP paths to route names", () => {
+    expect(resolveRoute("/")).toEqual({ name: "books" });
+    expect(resolveRoute("/books")).toEqual({ name: "books" });
+    expect(resolveRoute("/books/new")).toEqual({ name: "bookNew" });
+    expect(resolveRoute("/books/book-1")).toEqual({ name: "bookDetail", id: "book-1" });
+    expect(resolveRoute("/books/book-1/edit")).toEqual({ name: "bookEdit", id: "book-1" });
+    expect(resolveRoute("/locations")).toEqual({ name: "locations" });
+    expect(resolveRoute("/classification-tags")).toEqual({ name: "classificationTags" });
+    expect(resolveRoute("/data")).toEqual({ name: "data" });
+  });
+
+  it("returns notFound for unknown paths", () => {
+    expect(resolveRoute("/unknown")).toEqual({ name: "notFound" });
+  });
+});

--- a/Frontend/src/router.ts
+++ b/Frontend/src/router.ts
@@ -1,0 +1,54 @@
+export type Route =
+  | { name: "books" }
+  | { name: "bookNew" }
+  | { name: "bookDetail"; id: string }
+  | { name: "bookEdit"; id: string }
+  | { name: "locations" }
+  | { name: "classificationTags" }
+  | { name: "data" }
+  | { name: "notFound" };
+
+export function navigateTo(path: string) {
+  window.history.pushState({}, "", path);
+  window.dispatchEvent(new PopStateEvent("popstate"));
+}
+
+export function resolveRoute(pathname: string): Route {
+  if (pathname === "/") {
+    return { name: "books" };
+  }
+
+  if (pathname === "/books") {
+    return { name: "books" };
+  }
+
+  if (pathname === "/books/new") {
+    return { name: "bookNew" };
+  }
+
+  const bookEditMatch = pathname.match(/^\/books\/([^/]+)\/edit$/);
+
+  if (bookEditMatch) {
+    return { name: "bookEdit", id: decodeURIComponent(bookEditMatch[1]) };
+  }
+
+  const bookDetailMatch = pathname.match(/^\/books\/([^/]+)$/);
+
+  if (bookDetailMatch) {
+    return { name: "bookDetail", id: decodeURIComponent(bookDetailMatch[1]) };
+  }
+
+  if (pathname === "/locations") {
+    return { name: "locations" };
+  }
+
+  if (pathname === "/classification-tags") {
+    return { name: "classificationTags" };
+  }
+
+  if (pathname === "/data") {
+    return { name: "data" };
+  }
+
+  return { name: "notFound" };
+}

--- a/Frontend/src/styles.css
+++ b/Frontend/src/styles.css
@@ -1,10 +1,22 @@
 :root {
-  color: #1f2933;
-  background: #f4efe6;
-  font-family: "Yu Gothic", "Hiragino Sans", "Meiryo", sans-serif;
+  color: #243026;
+  background: #efe6d2;
+  font-family: "Yu Mincho", "Hiragino Mincho ProN", "Yu Gothic", "Meiryo", serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
+  --ink: #243026;
+  --muted: #667262;
+  --paper: #fffaf0;
+  --paper-soft: rgba(255, 250, 240, 0.78);
+  --cedar: #8a5738;
+  --moss: #556b4f;
+  --line: rgba(65, 55, 39, 0.16);
+  --shadow: 0 28px 90px rgba(65, 49, 27, 0.16);
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
@@ -13,61 +25,309 @@ body {
   min-height: 100vh;
 }
 
-.shell {
+a {
+  color: inherit;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+.app-shell {
   min-height: 100vh;
   display: grid;
-  place-items: center;
-  padding: 48px 24px;
+  grid-template-columns: 300px 1fr;
   background:
-    radial-gradient(circle at 20% 20%, rgba(184, 120, 68, 0.22), transparent 32%),
-    linear-gradient(135deg, #f8f2e9 0%, #d8e3d5 100%);
+    radial-gradient(circle at 12% 12%, rgba(202, 135, 80, 0.28), transparent 28%),
+    radial-gradient(circle at 90% 0%, rgba(92, 119, 85, 0.22), transparent 34%),
+    linear-gradient(135deg, #f8f1e4 0%, #d9e0cf 100%);
 }
 
-.hero {
-  max-width: 780px;
-  padding: 48px;
-  border: 1px solid rgba(76, 60, 42, 0.18);
-  border-radius: 28px;
-  background: rgba(255, 252, 245, 0.78);
-  box-shadow: 0 24px 80px rgba(68, 52, 35, 0.15);
+.sidebar {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  padding: 32px 24px;
+  border-right: 1px solid var(--line);
+  background: rgba(255, 250, 240, 0.72);
+  backdrop-filter: blur(22px);
 }
 
-.eyebrow {
-  margin: 0 0 16px;
-  color: #8b5e34;
-  font-size: 0.82rem;
-  font-weight: 700;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
+.brand {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  margin-bottom: 36px;
 }
 
-h1 {
+.brand-mark {
+  display: grid;
+  width: 54px;
+  height: 54px;
+  place-items: center;
+  border: 1px solid rgba(138, 87, 56, 0.38);
+  border-radius: 18px;
+  background: #2f3a2d;
+  color: #f6d59b;
+  font-weight: 800;
+  letter-spacing: -0.08em;
+  box-shadow: 0 18px 40px rgba(47, 58, 45, 0.22);
+}
+
+.brand h1,
+.page-heading h2,
+.state-block h2 {
   margin: 0;
-  font-size: clamp(2.1rem, 5vw, 4.8rem);
-  line-height: 1.08;
+}
+
+.brand h1 {
+  font-size: 1.45rem;
   letter-spacing: -0.06em;
 }
 
-.lead {
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--cedar);
+  font-family: "Yu Gothic", "Meiryo", sans-serif;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.nav-list {
+  display: grid;
+  gap: 10px;
+}
+
+.nav-link {
+  display: block;
+  padding: 14px 16px;
+  border: 1px solid transparent;
+  border-radius: 16px;
+  color: #435042;
+  font-family: "Yu Gothic", "Meiryo", sans-serif;
+  font-weight: 700;
+  text-decoration: none;
+  transition:
+    background 160ms ease,
+    border-color 160ms ease,
+    transform 160ms ease;
+}
+
+.nav-link:hover,
+.nav-link.active {
+  border-color: rgba(85, 107, 79, 0.24);
+  background: rgba(85, 107, 79, 0.12);
+  transform: translateX(4px);
+}
+
+.content-shell {
+  display: grid;
+  align-content: start;
+  gap: 24px;
+  padding: 32px;
+}
+
+.overview-card,
+.page-panel {
+  border: 1px solid var(--line);
+  border-radius: 28px;
+  background: var(--paper-soft);
+  box-shadow: var(--shadow);
+}
+
+.overview-card {
+  display: flex;
+  gap: 18px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 22px;
+}
+
+.overview-card code {
+  color: #385f40;
+  font-family: "Cascadia Code", "Consolas", monospace;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.page-panel {
+  min-height: 440px;
+  padding: clamp(28px, 5vw, 56px);
+}
+
+.page-heading {
+  max-width: 760px;
+  margin-bottom: 28px;
+}
+
+.page-heading h2 {
+  font-size: clamp(2.2rem, 5vw, 4.8rem);
+  line-height: 1.02;
+  letter-spacing: -0.08em;
+}
+
+.page-heading p:not(.eyebrow) {
   max-width: 680px;
-  margin: 24px 0 0;
-  color: #4f5f56;
-  font-size: 1.1rem;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-family: "Yu Gothic", "Meiryo", sans-serif;
   line-height: 1.8;
 }
 
-.panel {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
+.primary-action {
+  display: inline-flex;
   align-items: center;
-  margin-top: 32px;
-  padding: 16px 18px;
-  border-radius: 16px;
-  background: #1f2933;
-  color: #f8f2e9;
+  margin-top: 24px;
+  padding: 13px 18px;
+  border-radius: 999px;
+  background: #2f3a2d;
+  color: #fff5df;
+  font-family: "Yu Gothic", "Meiryo", sans-serif;
+  font-weight: 800;
+  text-decoration: none;
+  box-shadow: 0 16px 34px rgba(47, 58, 45, 0.22);
 }
 
-.panel code {
-  color: #f8c67a;
+.placeholder-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 28px;
+}
+
+.placeholder-grid > div {
+  min-height: 120px;
+  display: grid;
+  place-items: center;
+  padding: 18px;
+  border: 1px dashed rgba(85, 107, 79, 0.34);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.35);
+  color: #526150;
+  font-family: "Yu Gothic", "Meiryo", sans-serif;
+  font-weight: 700;
+}
+
+.state-block {
+  max-width: 680px;
+  padding: 20px;
+  border-radius: 20px;
+  font-family: "Yu Gothic", "Meiryo", sans-serif;
+}
+
+.state-block p {
+  margin: 8px 0 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.empty-state {
+  border: 1px solid rgba(85, 107, 79, 0.22);
+  background: rgba(85, 107, 79, 0.1);
+}
+
+.error-state {
+  border: 1px solid rgba(165, 72, 50, 0.32);
+  background: rgba(165, 72, 50, 0.1);
+}
+
+.loading-state {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding: 0;
+  background: transparent;
+}
+
+.loading-dot,
+.status-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: #5c7f4f;
+  box-shadow: 0 0 0 8px rgba(92, 127, 79, 0.16);
+}
+
+.loading-dot {
+  animation: pulse 1.1s ease-in-out infinite;
+}
+
+.health-badge {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  padding: 12px 14px;
+  border-radius: 18px;
+  background: rgba(85, 107, 79, 0.12);
+  font-family: "Yu Gothic", "Meiryo", sans-serif;
+}
+
+.health-badge div {
+  display: grid;
+  gap: 2px;
+}
+
+.health-badge span:last-child {
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(0.92);
+    opacity: 0.7;
+  }
+  50% {
+    transform: scale(1.12);
+    opacity: 1;
+  }
+}
+
+@media (max-width: 860px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: static;
+    height: auto;
+    padding: 20px;
+  }
+
+  .brand {
+    margin-bottom: 18px;
+  }
+
+  .nav-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .content-shell {
+    padding: 20px;
+  }
+
+  .overview-card {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .placeholder-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  .nav-list {
+    grid-template-columns: 1fr;
+  }
+
+  .page-panel {
+    padding: 24px;
+  }
 }


### PR DESCRIPTION
## Summary
- Add lightweight client-side routing for all MVP routes
- Redirect / to /books while keeping route resolution testable
- Add shared app layout, sidebar navigation, and responsive styling
- Add typed API client wrapper and backend health status display
- Add placeholder screens for books, book create/edit/detail, locations, classification tags, and data import/export
- Add loading, empty, and error state components
- Add router tests

## Verification
- mise run typecheck
- mise run lint
- mise run test
- mise run build
- docker compose --env-file .env.example config

Refs #5

Stacked on #20.