### PR TITLE
Frontend book list search and detail screens

### DIFF
--- a/Frontend/src/api/client.ts
+++ b/Frontend/src/api/client.ts
@@ -84,6 +84,21 @@ export type BookLookupResult = {
   classificationTagCandidates: string[];
 };
 
+export type ListBooksQuery = {
+  q?: string;
+  locationId?: string;
+  classificationTagId?: string;
+  page?: number;
+  limit?: number;
+};
+
+export type ListBooksResponse = {
+  items: Book[];
+  page: number;
+  limit: number;
+  total: number;
+};
+
 export type CreateLocationRequest = {
   name: string;
   description?: string;
@@ -145,6 +160,20 @@ export function getHealth() {
   return apiRequest<HealthResponse>("/api/health");
 }
 
+export function getBooks(query: ListBooksQuery = {}) {
+  const params = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(query)) {
+    if (value !== undefined && value !== "") {
+      params.set(key, String(value));
+    }
+  }
+
+  const search = params.toString();
+
+  return apiRequest<ListBooksResponse>(`/api/books${search ? `?${search}` : ""}`);
+}
+
 export function getBook(id: string) {
   return apiRequest<Book>(`/api/books/${encodeURIComponent(id)}`);
 }
@@ -160,6 +189,12 @@ export function updateBook(id: string, payload: BookFormRequest) {
   return apiRequest<Book>(`/api/books/${encodeURIComponent(id)}`, {
     body: JSON.stringify(payload),
     method: "PUT"
+  });
+}
+
+export function deleteBook(id: string) {
+  return apiRequest<void>(`/api/books/${encodeURIComponent(id)}`, {
+    method: "DELETE"
   });
 }
 

--- a/Frontend/src/pages/BookDetailPage.tsx
+++ b/Frontend/src/pages/BookDetailPage.tsx
@@ -1,20 +1,177 @@
+import { useEffect, useState } from "react";
+import { deleteBook, getBook, type ApiError, type Book } from "../api/client.js";
 import { Link } from "../components/Link.js";
+import { ErrorState, LoadingState } from "../components/StateBlocks.js";
+import { navigateTo } from "../router.js";
 
 type BookDetailPageProps = {
   bookId: string;
 };
 
 export function BookDetailPage({ bookId }: BookDetailPageProps) {
+  const [book, setBook] = useState<Book | null>(null);
+  const [error, setError] = useState<ApiError | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadBook() {
+      setIsLoading(true);
+
+      try {
+        const result = await getBook(bookId);
+
+        if (!isMounted) {
+          return;
+        }
+
+        setBook(result);
+        setError(null);
+      } catch (loadError) {
+        if (isMounted) {
+          setError(loadError as ApiError);
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void loadBook();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [bookId]);
+
+  async function handleDelete() {
+    if (!book || !window.confirm(`「${book.title}」を削除しますか？この操作は元に戻せません。`)) {
+      return;
+    }
+
+    setIsDeleting(true);
+
+    try {
+      await deleteBook(book.id);
+      navigateTo("/books");
+    } catch (deleteError) {
+      setError(deleteError as ApiError);
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
   return (
     <section className="page-panel">
       <div className="page-heading">
         <p className="eyebrow">Book Detail</p>
         <h2>本詳細</h2>
-        <p>対象ID: {bookId} の詳細情報、削除確認、編集導線を表示する画面にします。</p>
+        <p>登録済みの書誌情報、バーコード、保管場所、分類タグ、管理メモを確認できます。</p>
       </div>
-      <Link className="primary-action" href={`/books/${bookId}/edit`}>
-        編集画面へ
-      </Link>
+
+      {error ? <ErrorState title="本詳細の取得に失敗しました">{formatApiError(error)}</ErrorState> : null}
+
+      {isLoading ? <LoadingState title="本詳細を読み込み中" /> : null}
+
+      {!isLoading && book ? (
+        <article className="book-detail">
+          <header className="book-detail-hero">
+            <div>
+              <p className="eyebrow">{book.location?.name ?? "No Location"}</p>
+              <h3>{book.title}</h3>
+              <p>{book.author || "著者未設定"}</p>
+            </div>
+            <div className="card-actions">
+              <Link className="button-secondary link-button" href="/books">
+                一覧へ戻る
+              </Link>
+              <Link className="button-primary link-button" href={`/books/${book.id}/edit`}>
+                編集
+              </Link>
+              <button
+                className="button-danger"
+                disabled={isDeleting}
+                onClick={() => void handleDelete()}
+                type="button"
+              >
+                {isDeleting ? "削除中..." : "削除"}
+              </button>
+            </div>
+          </header>
+
+          <section className="detail-section">
+            <p className="eyebrow">Bibliography</p>
+            <dl className="detail-grid">
+              <DetailItem label="著者" value={book.author} />
+              <DetailItem label="出版社" value={book.publisher} />
+              <DetailItem label="出版日" value={book.publishedDate} />
+              <DetailItem label="ISBN" value={book.isbn} />
+            </dl>
+          </section>
+
+          <section className="detail-section">
+            <p className="eyebrow">Barcodes</p>
+            <dl className="detail-grid">
+              <DetailItem label="本のバーコード" value={book.bookBarcode} />
+              <DetailItem label="管理用バーコード" value={book.managementBarcode} />
+              <DetailItem label="外部ソース" value={formatExternalSource(book.externalSource)} />
+              <DetailItem label="外部ID" value={book.externalId} />
+            </dl>
+          </section>
+
+          <section className="detail-section">
+            <p className="eyebrow">Management</p>
+            <dl className="detail-grid">
+              <DetailItem label="保管場所" value={book.location?.name} />
+              <DetailItem label="登録日時" value={formatDate(book.createdAt)} />
+              <DetailItem label="更新日時" value={formatDate(book.updatedAt)} />
+            </dl>
+            <div className="book-tag-row detail-tags">
+              {book.classificationTags.length > 0 ? (
+                book.classificationTags.map((tag) => <span key={tag.id}>{tag.name}</span>)
+              ) : (
+                <span>分類なし</span>
+              )}
+            </div>
+          </section>
+
+          <section className="detail-section">
+            <p className="eyebrow">Memo</p>
+            <p className="memo-box">{book.managementMemo || "管理メモはありません。"}</p>
+          </section>
+        </article>
+      ) : null}
     </section>
   );
+}
+
+function DetailItem({ label, value }: { label: string; value?: string | null }) {
+  return (
+    <div>
+      <dt>{label}</dt>
+      <dd>{value || "-"}</dd>
+    </div>
+  );
+}
+
+function formatApiError(error: ApiError) {
+  if (!error.errors?.length) {
+    return error.message;
+  }
+
+  return `${error.message}: ${error.errors.map((item) => item.message).join(", ")}`;
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("ja-JP", {
+    dateStyle: "medium",
+    timeStyle: "short"
+  }).format(new Date(value));
+}
+
+function formatExternalSource(source: string | null) {
+  return source === "open_library" ? "Open Library" : source;
 }

--- a/Frontend/src/pages/BooksPage.tsx
+++ b/Frontend/src/pages/BooksPage.tsx
@@ -1,20 +1,314 @@
+import { type FormEvent, useEffect, useState } from "react";
+import {
+  getBooks,
+  getClassificationTags,
+  getLocations,
+  type ApiError,
+  type Book,
+  type ClassificationTag,
+  type Location
+} from "../api/client.js";
 import { Link } from "../components/Link.js";
-import { EmptyState } from "../components/StateBlocks.js";
+import { EmptyState, ErrorState, LoadingState } from "../components/StateBlocks.js";
+
+const pageSize = 20;
+
+type SearchState = {
+  classificationTagId: string;
+  locationId: string;
+  q: string;
+};
+
+const emptySearch: SearchState = {
+  classificationTagId: "",
+  locationId: "",
+  q: ""
+};
 
 export function BooksPage() {
+  const [books, setBooks] = useState<Book[]>([]);
+  const [error, setError] = useState<ApiError | null>(null);
+  const [filters, setFilters] = useState<SearchState>(emptySearch);
+  const [locations, setLocations] = useState<Location[]>([]);
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState<SearchState>(emptySearch);
+  const [tags, setTags] = useState<ClassificationTag[]>([]);
+  const [total, setTotal] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadFilterOptions() {
+      try {
+        const [locationResult, tagResult] = await Promise.all([getLocations(), getClassificationTags()]);
+
+        if (!isMounted) {
+          return;
+        }
+
+        setLocations(locationResult.items);
+        setTags(tagResult.items);
+      } catch (loadError) {
+        if (isMounted) {
+          setError(loadError as ApiError);
+        }
+      }
+    }
+
+    void loadFilterOptions();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadBooks() {
+      setIsLoading(true);
+
+      try {
+        const result = await getBooks({
+          classificationTagId: filters.classificationTagId || undefined,
+          limit: pageSize,
+          locationId: filters.locationId || undefined,
+          page,
+          q: filters.q.trim() || undefined
+        });
+
+        if (!isMounted) {
+          return;
+        }
+
+        setBooks(result.items);
+        setTotal(result.total);
+        setError(null);
+      } catch (loadError) {
+        if (isMounted) {
+          setError(loadError as ApiError);
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void loadBooks();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [filters, page]);
+
+  function handleSearchSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setPage(1);
+    setFilters(search);
+  }
+
+  function handleFilterChange(nextSearch: SearchState) {
+    setSearch(nextSearch);
+    setFilters(nextSearch);
+    setPage(1);
+  }
+
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const hasActiveFilters = Boolean(filters.q || filters.locationId || filters.classificationTagId);
+
   return (
     <section className="page-panel">
       <div className="page-heading">
         <p className="eyebrow">Books</p>
         <h2>本一覧</h2>
-        <p>タイトル、著者、ISBN、本のバーコード、管理用バーコードで検索できる画面にします。</p>
+        <p>タイトル、著者、ISBN、本のバーコード、管理用バーコードから探せます。保管場所と分類タグでも絞り込めます。</p>
       </div>
-      <EmptyState title="まだ本一覧UIは未実装です">
-        次の画面実装Issueで、検索、保管場所絞り込み、分類タグ絞り込み、詳細導線を追加します。
-      </EmptyState>
-      <Link className="primary-action" href="/books/new">
-        本登録画面へ
-      </Link>
+
+      {error ? <ErrorState title="本一覧の取得に失敗しました">{formatApiError(error)}</ErrorState> : null}
+
+      <section className="book-list-toolbar" aria-label="本の検索条件">
+        <form className="book-search-form" onSubmit={handleSearchSubmit}>
+          <label>
+            <span>キーワード</span>
+            <input
+              onChange={(event) => setSearch({ ...search, q: event.target.value })}
+              placeholder="タイトル、著者、ISBN、バーコード"
+              value={search.q}
+            />
+          </label>
+          <button className="button-primary" type="submit">
+            検索
+          </button>
+        </form>
+
+        <div className="filter-row">
+          <label>
+            <span>保管場所</span>
+            <select
+              onChange={(event) => handleFilterChange({ ...search, locationId: event.target.value })}
+              value={search.locationId}
+            >
+              <option value="">すべて</option>
+              {locations.map((location) => (
+                <option key={location.id} value={location.id}>
+                  {location.name}
+                  {location.isActive ? "" : "（無効）"}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label>
+            <span>分類タグ</span>
+            <select
+              onChange={(event) =>
+                handleFilterChange({ ...search, classificationTagId: event.target.value })
+              }
+              value={search.classificationTagId}
+            >
+              <option value="">すべて</option>
+              {tags.map((tag) => (
+                <option key={tag.id} value={tag.id}>
+                  {tag.name}
+                  {tag.isActive ? "" : "（無効）"}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <button
+            className="button-secondary"
+            onClick={() => {
+              setSearch(emptySearch);
+              setFilters(emptySearch);
+              setPage(1);
+            }}
+            type="button"
+          >
+            条件をクリア
+          </button>
+
+          <Link className="button-primary link-button" href="/books/new">
+            本を登録
+          </Link>
+        </div>
+      </section>
+
+      <div className="result-summary">
+        <strong>{total}</strong>
+        <span>冊</span>
+        {hasActiveFilters ? <span>現在の条件で絞り込み中</span> : <span>登録済みの本</span>}
+      </div>
+
+      {isLoading ? <LoadingState title="本を読み込み中" /> : null}
+
+      {!isLoading && books.length === 0 && !hasActiveFilters ? (
+        <EmptyState title="まだ本が登録されていません">
+          まずは本登録画面から、バーコード照会または手入力で1冊追加してみましょう。
+        </EmptyState>
+      ) : null}
+
+      {!isLoading && books.length === 0 && hasActiveFilters ? (
+        <EmptyState title="条件に一致する本がありません">
+          検索語、保管場所、分類タグの条件を少し広げると見つかるかもしれません。
+        </EmptyState>
+      ) : null}
+
+      {!isLoading && books.length > 0 ? (
+        <>
+          <div className="book-card-list">
+            {books.map((book) => (
+              <BookCard book={book} key={book.id} />
+            ))}
+          </div>
+
+          <div className="pagination-bar">
+            <button
+              className="button-secondary"
+              disabled={page <= 1}
+              onClick={() => setPage((current) => Math.max(1, current - 1))}
+              type="button"
+            >
+              前へ
+            </button>
+            <span>
+              {page} / {totalPages}
+            </span>
+            <button
+              className="button-secondary"
+              disabled={page >= totalPages}
+              onClick={() => setPage((current) => Math.min(totalPages, current + 1))}
+              type="button"
+            >
+              次へ
+            </button>
+          </div>
+        </>
+      ) : null}
     </section>
   );
+}
+
+function BookCard({ book }: { book: Book }) {
+  return (
+    <article className="book-card">
+      <div>
+        <p className="eyebrow">{book.location?.name ?? "No Location"}</p>
+        <h3>
+          <Link href={`/books/${book.id}`}>{book.title}</Link>
+        </h3>
+        <p>{book.author || "著者未設定"}</p>
+      </div>
+      <dl className="book-meta-grid">
+        <div>
+          <dt>ISBN</dt>
+          <dd>{book.isbn || "-"}</dd>
+        </div>
+        <div>
+          <dt>本のバーコード</dt>
+          <dd>{book.bookBarcode || "-"}</dd>
+        </div>
+        <div>
+          <dt>管理用バーコード</dt>
+          <dd>{book.managementBarcode || "-"}</dd>
+        </div>
+        <div>
+          <dt>更新</dt>
+          <dd>{formatDate(book.updatedAt)}</dd>
+        </div>
+      </dl>
+      <div className="book-tag-row">
+        {book.classificationTags.length > 0 ? (
+          book.classificationTags.map((tag) => <span key={tag.id}>{tag.name}</span>)
+        ) : (
+          <span>分類なし</span>
+        )}
+      </div>
+      <div className="card-actions">
+        <Link className="button-secondary link-button" href={`/books/${book.id}`}>
+          詳細
+        </Link>
+        <Link className="button-secondary link-button" href={`/books/${book.id}/edit`}>
+          編集
+        </Link>
+      </div>
+    </article>
+  );
+}
+
+function formatApiError(error: ApiError) {
+  if (!error.errors?.length) {
+    return error.message;
+  }
+
+  return `${error.message}: ${error.errors.map((item) => item.message).join(", ")}`;
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("ja-JP", {
+    dateStyle: "medium",
+    timeStyle: "short"
+  }).format(new Date(value));
 }

--- a/Frontend/src/styles.css
+++ b/Frontend/src/styles.css
@@ -358,6 +358,222 @@ button:disabled {
   width: 100%;
 }
 
+.link-button {
+  text-decoration: none;
+}
+
+.book-list-toolbar {
+  display: grid;
+  gap: 14px;
+  margin-bottom: 22px;
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  background: rgba(255, 250, 240, 0.62);
+}
+
+.book-search-form,
+.filter-row {
+  display: grid;
+  gap: 12px;
+  align-items: end;
+}
+
+.book-search-form {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.filter-row {
+  grid-template-columns: repeat(2, minmax(0, 1fr)) auto auto;
+}
+
+.book-search-form label,
+.filter-row label {
+  display: grid;
+  gap: 7px;
+  color: #3d493b;
+  font-family: "Yu Gothic", "Meiryo", sans-serif;
+  font-weight: 800;
+}
+
+.book-search-form input,
+.filter-row select {
+  width: 100%;
+  min-height: 46px;
+  padding: 0 14px;
+  border: 1px solid rgba(65, 55, 39, 0.18);
+  border-radius: 15px;
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--ink);
+  font-family: "Yu Gothic", "Meiryo", sans-serif;
+  font-weight: 600;
+}
+
+.result-summary {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  margin: 0 0 18px;
+  color: var(--muted);
+  font-family: "Yu Gothic", "Meiryo", sans-serif;
+  font-weight: 700;
+}
+
+.result-summary strong {
+  color: var(--ink);
+  font-size: 1.8rem;
+}
+
+.book-card-list {
+  display: grid;
+  gap: 14px;
+}
+
+.book-card,
+.book-detail {
+  border: 1px solid rgba(85, 107, 79, 0.18);
+  border-radius: 24px;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.64), rgba(255, 250, 240, 0.5)),
+    rgba(255, 255, 255, 0.36);
+  box-shadow: 0 20px 60px rgba(65, 49, 27, 0.08);
+}
+
+.book-card {
+  display: grid;
+  grid-template-columns: minmax(220px, 1.15fr) minmax(320px, 1fr) minmax(160px, 0.8fr) auto;
+  gap: 18px;
+  align-items: center;
+  padding: 18px;
+}
+
+.book-card h3,
+.book-detail h3 {
+  margin: 0;
+  letter-spacing: -0.04em;
+}
+
+.book-card h3 a {
+  text-decoration: none;
+}
+
+.book-card p,
+.book-detail-hero p,
+.memo-box {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-family: "Yu Gothic", "Meiryo", sans-serif;
+  line-height: 1.7;
+}
+
+.book-meta-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px 16px;
+  margin: 0;
+  font-family: "Yu Gothic", "Meiryo", sans-serif;
+}
+
+.book-meta-grid div,
+.detail-grid div {
+  display: grid;
+  gap: 3px;
+}
+
+.book-meta-grid dt,
+.detail-grid dt {
+  color: var(--cedar);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}
+
+.book-meta-grid dd,
+.detail-grid dd {
+  min-width: 0;
+  margin: 0;
+  color: #3f4b3d;
+  font-weight: 800;
+  overflow-wrap: anywhere;
+}
+
+.book-tag-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.book-tag-row span {
+  display: inline-flex;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(85, 107, 79, 0.12);
+  color: #3f6639;
+  font-family: "Yu Gothic", "Meiryo", sans-serif;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.pagination-bar {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  justify-content: center;
+  margin-top: 20px;
+  color: #3f4b3d;
+  font-family: "Yu Gothic", "Meiryo", sans-serif;
+  font-weight: 800;
+}
+
+.book-detail {
+  display: grid;
+  gap: 18px;
+  padding: 22px;
+}
+
+.book-detail-hero {
+  display: flex;
+  gap: 18px;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--line);
+}
+
+.book-detail-hero h3 {
+  font-size: clamp(2rem, 4vw, 3.6rem);
+  line-height: 1.05;
+}
+
+.detail-section {
+  display: grid;
+  gap: 12px;
+  padding: 18px;
+  border: 1px solid rgba(65, 55, 39, 0.12);
+  border-radius: 20px;
+  background: rgba(255, 250, 240, 0.48);
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  margin: 0;
+  font-family: "Yu Gothic", "Meiryo", sans-serif;
+}
+
+.detail-tags {
+  margin-top: 4px;
+}
+
+.memo-box {
+  min-height: 72px;
+  padding: 16px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.5);
+  white-space: pre-wrap;
+}
+
 .management-form,
 .management-list {
   border: 1px solid var(--line);
@@ -676,12 +892,20 @@ button:disabled {
   }
 
   .book-form-layout,
+  .book-search-form,
+  .filter-row,
+  .book-card,
+  .detail-grid,
   .field-pair {
     grid-template-columns: 1fr;
   }
 
   .book-form-side {
     position: static;
+  }
+
+  .book-detail-hero {
+    flex-direction: column;
   }
 
   .management-form {


### PR DESCRIPTION
## Summary
- Add frontend book list and delete API helpers
- Implement /books with keyword search, location filter, classification tag filter, pagination, empty states, and detail/edit links
- Implement /books/:id with all MVP book fields, edit link, list return link, and delete confirmation
- Add responsive card/detail styles for mobile-friendly browsing

## Verification
- mise run typecheck
- mise run test
- mise run build
- mise run lint
- docker compose --env-file .env.example config

Refs #12