### PR TITLE
Frontend JSON export and import screen

### DIFF
--- a/Frontend/src/api/client.ts
+++ b/Frontend/src/api/client.ts
@@ -99,6 +99,70 @@ export type ListBooksResponse = {
   total: number;
 };
 
+export type JsonExportPayload = {
+  version: 1;
+  exportedAt?: string;
+  books: Array<Record<string, unknown>>;
+  locations: Array<Record<string, unknown>>;
+  classificationTags: Array<Record<string, unknown>>;
+  bookClassificationTags: Array<Record<string, unknown>>;
+};
+
+export type ImportAction = "overwrite" | "skip";
+export type ImportEntity = "book" | "location" | "classificationTag";
+
+export type ImportConflict = {
+  entity: ImportEntity;
+  matchBy: "id" | "managementBarcode" | "name";
+  incomingId: string;
+  existingId: string;
+  defaultAction: "skip";
+  availableActions: ImportAction[];
+};
+
+export type ImportPreview = {
+  summary: {
+    create: number;
+    conflict: number;
+    error: number;
+  };
+  conflicts: ImportConflict[];
+  errors: Array<{
+    field: string;
+    message: string;
+  }>;
+};
+
+export type ImportRequest = JsonExportPayload & {
+  conflictResolution?: {
+    defaultAction: ImportAction;
+    items: Array<{
+      entity: ImportEntity;
+      incomingId: string;
+      existingId: string;
+      action: ImportAction;
+    }>;
+  };
+};
+
+export type ImportResult = {
+  imported: {
+    books: number;
+    locations: number;
+    classificationTags: number;
+  };
+  overwritten: {
+    books: number;
+    locations: number;
+    classificationTags: number;
+  };
+  skipped: {
+    books: number;
+    locations: number;
+    classificationTags: number;
+  };
+};
+
 export type CreateLocationRequest = {
   name: string;
   description?: string;
@@ -158,6 +222,24 @@ export async function apiRequest<T>(path: string, init?: RequestInit): Promise<T
 
 export function getHealth() {
   return apiRequest<HealthResponse>("/api/health");
+}
+
+export function exportJsonData() {
+  return apiRequest<JsonExportPayload>("/api/export");
+}
+
+export function previewJsonImport(payload: JsonExportPayload) {
+  return apiRequest<ImportPreview>("/api/import/preview", {
+    body: JSON.stringify(payload),
+    method: "POST"
+  });
+}
+
+export function importJsonData(payload: ImportRequest) {
+  return apiRequest<ImportResult>("/api/import", {
+    body: JSON.stringify(payload),
+    method: "POST"
+  });
 }
 
 export function getBooks(query: ListBooksQuery = {}) {

--- a/Frontend/src/pages/DataPage.tsx
+++ b/Frontend/src/pages/DataPage.tsx
@@ -1,16 +1,409 @@
+import { type ChangeEvent, useState } from "react";
+import {
+  exportJsonData,
+  importJsonData,
+  previewJsonImport,
+  type ApiError,
+  type ImportAction,
+  type ImportConflict,
+  type ImportPreview,
+  type ImportResult,
+  type JsonExportPayload
+} from "../api/client.js";
+import { ErrorState } from "../components/StateBlocks.js";
+
+type ConflictActions = Record<string, ImportAction>;
+
 export function DataPage() {
+  const [conflictActions, setConflictActions] = useState<ConflictActions>({});
+  const [defaultAction, setDefaultAction] = useState<ImportAction>("skip");
+  const [error, setError] = useState<ApiError | null>(null);
+  const [exportMessage, setExportMessage] = useState<string | null>(null);
+  const [importPayload, setImportPayload] = useState<JsonExportPayload | null>(null);
+  const [importResult, setImportResult] = useState<ImportResult | null>(null);
+  const [isExporting, setIsExporting] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
+  const [isPreviewing, setIsPreviewing] = useState(false);
+  const [jsonText, setJsonText] = useState("");
+  const [preview, setPreview] = useState<ImportPreview | null>(null);
+
+  async function handleExport() {
+    setIsExporting(true);
+    setExportMessage(null);
+    setError(null);
+
+    try {
+      const payload = await exportJsonData();
+      downloadJson(payload);
+      setExportMessage("JSON Exportを作成しました。復元や移行にはこのJSONを使います。");
+    } catch (exportError) {
+      setError(exportError as ApiError);
+    } finally {
+      setIsExporting(false);
+    }
+  }
+
+  async function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    const text = await file.text();
+    setJsonText(text);
+    await previewText(text);
+    event.target.value = "";
+  }
+
+  async function handlePreview() {
+    await previewText(jsonText);
+  }
+
+  async function previewText(text: string) {
+    setError(null);
+    setImportResult(null);
+    setPreview(null);
+    setImportPayload(null);
+
+    if (!text.trim()) {
+      setError({
+        message: "ImportするJSONを選択または貼り付けてください。",
+        status: 400
+      });
+      return;
+    }
+
+    let parsed: JsonExportPayload;
+
+    try {
+      parsed = JSON.parse(text) as JsonExportPayload;
+    } catch {
+      setError({
+        message: "JSONとして読み取れませんでした。ファイル内容を確認してください。",
+        status: 400
+      });
+      return;
+    }
+
+    setIsPreviewing(true);
+
+    try {
+      const result = await previewJsonImport(parsed);
+      setImportPayload(parsed);
+      setPreview(result);
+      setDefaultAction("skip");
+      setConflictActions(createInitialConflictActions(result.conflicts, "skip"));
+    } catch (previewError) {
+      setError(previewError as ApiError);
+    } finally {
+      setIsPreviewing(false);
+    }
+  }
+
+  async function handleImport() {
+    if (!importPayload || !preview) {
+      return;
+    }
+
+    if (preview.summary.error > 0) {
+      setError({
+        message: "Importできないエラーがあります。JSONの内容を修正してから再度プレビューしてください。",
+        status: 400
+      });
+      return;
+    }
+
+    if (!window.confirm("プレビュー内容に従ってImportを実行しますか？")) {
+      return;
+    }
+
+    setIsImporting(true);
+    setError(null);
+
+    try {
+      const result = await importJsonData({
+        ...importPayload,
+        conflictResolution: {
+          defaultAction,
+          items: preview.conflicts.map((conflict) => ({
+            entity: conflict.entity,
+            incomingId: conflict.incomingId,
+            existingId: conflict.existingId,
+            action: conflictActions[conflictKey(conflict)] ?? defaultAction
+          }))
+        }
+      });
+
+      setImportResult(result);
+    } catch (importError) {
+      setError(importError as ApiError);
+    } finally {
+      setIsImporting(false);
+    }
+  }
+
+  function applyAllConflicts(action: ImportAction) {
+    setDefaultAction(action);
+    setConflictActions(createInitialConflictActions(preview?.conflicts ?? [], action));
+  }
+
+  function setConflictAction(conflict: ImportConflict, action: ImportAction) {
+    setConflictActions((current) => ({
+      ...current,
+      [conflictKey(conflict)]: action
+    }));
+  }
+
   return (
     <section className="page-panel">
       <div className="page-heading">
         <p className="eyebrow">Data</p>
         <h2>データ入出力</h2>
-        <p>JSON Export/Import、Importプレビュー、重複時の上書き/無視選択を扱う画面にします。</p>
+        <p>
+          JSONはバックアップ、移行、復元用の正式形式です。Importは必ずプレビューして、重複時はWindowsのコピーのように上書き/無視を選べます。
+        </p>
       </div>
-      <div className="placeholder-grid">
-        <div>Export</div>
-        <div>Import Preview</div>
-        <div>Conflict Resolution</div>
+
+      {error ? <ErrorState title="データ入出力に失敗しました">{formatApiError(error)}</ErrorState> : null}
+
+      <div className="data-flow-grid">
+        <section className="data-card">
+          <div>
+            <p className="eyebrow">JSON Export</p>
+            <h3>バックアップを書き出す</h3>
+            <p>本、保管場所、分類タグ、タグの紐づけをJSONとして保存します。</p>
+          </div>
+          <button className="button-primary" disabled={isExporting} onClick={() => void handleExport()} type="button">
+            {isExporting ? "Export中..." : "JSONをExport"}
+          </button>
+          {exportMessage ? <p className="inline-message">{exportMessage}</p> : null}
+        </section>
+
+        <section className="data-card">
+          <div>
+            <p className="eyebrow">JSON Import</p>
+            <h3>JSONを読み込む</h3>
+            <p>ExportしたJSONファイルを選ぶか、内容を貼り付けてプレビューします。</p>
+          </div>
+
+          <label className="file-input-label">
+            <span>JSONファイル</span>
+            <input accept=".json,application/json" onChange={(event) => void handleFileChange(event)} type="file" />
+          </label>
+
+          <label className="json-paste-field">
+            <span>JSON貼り付け</span>
+            <textarea
+              onChange={(event) => setJsonText(event.target.value)}
+              placeholder='{"version":1,"books":[],"locations":[],"classificationTags":[],"bookClassificationTags":[]}'
+              value={jsonText}
+            />
+          </label>
+
+          <button className="button-secondary" disabled={isPreviewing} onClick={() => void handlePreview()} type="button">
+            {isPreviewing ? "プレビュー中..." : "Importプレビュー"}
+          </button>
+        </section>
       </div>
+
+      {preview ? (
+        <section className="import-preview-panel">
+          <div className="list-heading">
+            <div>
+              <p className="eyebrow">Import Preview</p>
+              <h3>Importプレビュー</h3>
+            </div>
+            <button
+              className="button-primary"
+              disabled={isImporting || preview.summary.error > 0}
+              onClick={() => void handleImport()}
+              type="button"
+            >
+              {isImporting ? "Import中..." : "この内容でImport"}
+            </button>
+          </div>
+
+          <div className="import-summary-grid">
+            <SummaryCard label="追加候補" value={preview.summary.create} />
+            <SummaryCard label="競合" value={preview.summary.conflict} />
+            <SummaryCard label="エラー" value={preview.summary.error} tone={preview.summary.error > 0 ? "danger" : "normal"} />
+          </div>
+
+          {preview.errors.length > 0 ? (
+            <section className="preview-section danger">
+              <h4>Importできないエラー</h4>
+              <div className="issue-list">
+                {preview.errors.map((item) => (
+                  <article key={`${item.field}:${item.message}`}>
+                    <strong>{item.field}</strong>
+                    <p>{item.message}</p>
+                  </article>
+                ))}
+              </div>
+            </section>
+          ) : null}
+
+          <section className="preview-section">
+            <div className="conflict-toolbar">
+              <div>
+                <h4>重複時の処理</h4>
+                <p>初期状態はすべて無視です。必要な項目だけ上書きに切り替えられます。</p>
+              </div>
+              <div className="form-actions">
+                <button className="button-secondary" onClick={() => applyAllConflicts("skip")} type="button">
+                  すべて無視
+                </button>
+                <button className="button-danger" onClick={() => applyAllConflicts("overwrite")} type="button">
+                  すべて上書き
+                </button>
+              </div>
+            </div>
+
+            {preview.conflicts.length === 0 ? (
+              <p className="subtle-text">重複はありません。新しいデータとして追加されます。</p>
+            ) : (
+              <div className="conflict-list">
+                {preview.conflicts.map((conflict) => (
+                  <article className="conflict-card" key={conflictKey(conflict)}>
+                    <div>
+                      <span className="status-pill">{formatEntity(conflict.entity)}</span>
+                      <h5>{formatMatchBy(conflict.matchBy)} が重複しています</h5>
+                      <dl className="meta-list">
+                        <div>
+                          <dt>Import ID</dt>
+                          <dd>{conflict.incomingId}</dd>
+                        </div>
+                        <div>
+                          <dt>既存 ID</dt>
+                          <dd>{conflict.existingId}</dd>
+                        </div>
+                      </dl>
+                    </div>
+                    <div className="conflict-actions" aria-label="競合解決">
+                      <label>
+                        <input
+                          checked={(conflictActions[conflictKey(conflict)] ?? defaultAction) === "skip"}
+                          onChange={() => setConflictAction(conflict, "skip")}
+                          type="radio"
+                        />
+                        <span>無視</span>
+                      </label>
+                      <label>
+                        <input
+                          checked={(conflictActions[conflictKey(conflict)] ?? defaultAction) === "overwrite"}
+                          onChange={() => setConflictAction(conflict, "overwrite")}
+                          type="radio"
+                        />
+                        <span>上書き</span>
+                      </label>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            )}
+          </section>
+        </section>
+      ) : null}
+
+      {importResult ? (
+        <section className="import-preview-panel result">
+          <p className="eyebrow">Import Result</p>
+          <h3>Import結果</h3>
+          <div className="import-result-grid">
+            <ResultGroup title="追加" values={importResult.imported} />
+            <ResultGroup title="上書き" values={importResult.overwritten} />
+            <ResultGroup title="無視" values={importResult.skipped} />
+          </div>
+        </section>
+      ) : null}
     </section>
   );
+}
+
+function SummaryCard({ label, tone = "normal", value }: { label: string; tone?: "danger" | "normal"; value: number }) {
+  return (
+    <article className={tone === "danger" ? "summary-card danger" : "summary-card"}>
+      <strong>{value}</strong>
+      <span>{label}</span>
+    </article>
+  );
+}
+
+function ResultGroup({
+  title,
+  values
+}: {
+  title: string;
+  values: { books: number; locations: number; classificationTags: number };
+}) {
+  return (
+    <article className="result-group">
+      <h4>{title}</h4>
+      <dl className="meta-list">
+        <div>
+          <dt>本</dt>
+          <dd>{values.books}</dd>
+        </div>
+        <div>
+          <dt>保管場所</dt>
+          <dd>{values.locations}</dd>
+        </div>
+        <div>
+          <dt>分類タグ</dt>
+          <dd>{values.classificationTags}</dd>
+        </div>
+      </dl>
+    </article>
+  );
+}
+
+function createInitialConflictActions(conflicts: ImportConflict[], action: ImportAction) {
+  return Object.fromEntries(conflicts.map((conflict) => [conflictKey(conflict), action]));
+}
+
+function conflictKey(conflict: Pick<ImportConflict, "entity" | "existingId" | "incomingId">) {
+  return `${conflict.entity}:${conflict.incomingId}:${conflict.existingId}`;
+}
+
+function downloadJson(payload: JsonExportPayload) {
+  const blob = new Blob([JSON.stringify(payload, null, 2)], {
+    type: "application/json"
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `book-manager-export-${new Date().toISOString().slice(0, 10)}.json`;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+function formatApiError(error: ApiError) {
+  if (!error.errors?.length) {
+    return error.message;
+  }
+
+  return `${error.message}: ${error.errors.map((item) => `${item.field} ${item.message}`).join(", ")}`;
+}
+
+function formatEntity(entity: ImportConflict["entity"]) {
+  switch (entity) {
+    case "book":
+      return "本";
+    case "classificationTag":
+      return "分類タグ";
+    case "location":
+      return "保管場所";
+  }
+}
+
+function formatMatchBy(matchBy: ImportConflict["matchBy"]) {
+  switch (matchBy) {
+    case "id":
+      return "ID";
+    case "managementBarcode":
+      return "管理用バーコード";
+    case "name":
+      return "名前";
+  }
 }

--- a/Frontend/src/styles.css
+++ b/Frontend/src/styles.css
@@ -229,6 +229,200 @@ button:disabled {
   align-items: start;
 }
 
+.data-flow-grid {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.8fr) minmax(320px, 1.2fr);
+  gap: 22px;
+  align-items: start;
+}
+
+.data-card,
+.import-preview-panel {
+  display: grid;
+  gap: 18px;
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  background: rgba(255, 250, 240, 0.64);
+  box-shadow: 0 20px 60px rgba(65, 49, 27, 0.08);
+}
+
+.data-card h3,
+.import-preview-panel h3,
+.preview-section h4,
+.conflict-card h5,
+.result-group h4 {
+  margin: 0;
+}
+
+.data-card p,
+.conflict-toolbar p {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-family: "Yu Gothic", "Meiryo", sans-serif;
+  line-height: 1.7;
+}
+
+.file-input-label,
+.json-paste-field {
+  display: grid;
+  gap: 8px;
+  color: #3d493b;
+  font-family: "Yu Gothic", "Meiryo", sans-serif;
+  font-weight: 800;
+}
+
+.file-input-label input,
+.json-paste-field textarea {
+  width: 100%;
+  border: 1px solid rgba(65, 55, 39, 0.18);
+  border-radius: 15px;
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--ink);
+  font-family: "Yu Gothic", "Meiryo", sans-serif;
+  font-weight: 600;
+}
+
+.file-input-label input {
+  min-height: 46px;
+  padding: 10px 14px;
+}
+
+.json-paste-field textarea {
+  min-height: 220px;
+  padding: 12px 14px;
+  font-family: "Cascadia Code", "Consolas", monospace;
+  resize: vertical;
+}
+
+.import-preview-panel {
+  margin-top: 22px;
+}
+
+.import-preview-panel.result {
+  background:
+    radial-gradient(circle at 12% 12%, rgba(92, 127, 79, 0.16), transparent 32%),
+    rgba(255, 250, 240, 0.7);
+}
+
+.import-summary-grid,
+.import-result-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.summary-card,
+.result-group {
+  display: grid;
+  gap: 8px;
+  padding: 16px;
+  border: 1px solid rgba(85, 107, 79, 0.18);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.48);
+  font-family: "Yu Gothic", "Meiryo", sans-serif;
+}
+
+.summary-card strong {
+  color: var(--ink);
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.summary-card span {
+  color: var(--muted);
+  font-weight: 800;
+}
+
+.summary-card.danger {
+  border-color: rgba(165, 72, 50, 0.32);
+  background: rgba(165, 72, 50, 0.1);
+}
+
+.preview-section {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+  border: 1px solid rgba(65, 55, 39, 0.12);
+  border-radius: 20px;
+  background: rgba(255, 250, 240, 0.48);
+}
+
+.preview-section.danger {
+  border-color: rgba(165, 72, 50, 0.32);
+  background: rgba(165, 72, 50, 0.08);
+}
+
+.issue-list,
+.conflict-list {
+  display: grid;
+  gap: 12px;
+}
+
+.issue-list article,
+.conflict-card {
+  padding: 16px;
+  border: 1px solid rgba(85, 107, 79, 0.18);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.issue-list strong {
+  color: #8d3f2b;
+  font-family: "Cascadia Code", "Consolas", monospace;
+}
+
+.issue-list p {
+  margin: 6px 0 0;
+  color: var(--muted);
+  font-family: "Yu Gothic", "Meiryo", sans-serif;
+  line-height: 1.7;
+}
+
+.conflict-toolbar,
+.conflict-card {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.conflict-card {
+  align-items: center;
+}
+
+.conflict-card h5 {
+  margin-top: 10px;
+  color: #3f4b3d;
+  font-family: "Yu Gothic", "Meiryo", sans-serif;
+  font-size: 1rem;
+}
+
+.conflict-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.conflict-actions label {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  min-height: 38px;
+  padding: 7px 11px;
+  border: 1px solid rgba(85, 107, 79, 0.2);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.5);
+  color: #354433;
+  font-family: "Yu Gothic", "Meiryo", sans-serif;
+  font-weight: 800;
+}
+
+.conflict-actions input {
+  width: 16px;
+  min-height: 16px;
+}
+
 .book-form-layout {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
@@ -987,6 +1181,17 @@ button:disabled {
 
   .management-grid {
     grid-template-columns: 1fr;
+  }
+
+  .data-flow-grid,
+  .import-summary-grid,
+  .import-result-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .conflict-toolbar,
+  .conflict-card {
+    flex-direction: column;
   }
 
   .book-form-layout,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
       BACKEND_PORT: ${BACKEND_PORT:-3001}
       CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:3000}
       DATABASE_PATH: /data/book-manager.sqlite
+      OPEN_LIBRARY_APP_NAME: ${OPEN_LIBRARY_APP_NAME:-book-manager}
+      OPEN_LIBRARY_CONTACT: ${OPEN_LIBRARY_CONTACT:-}
     ports:
       - "${BACKEND_PORT:-3001}:3001"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,9 @@ services:
   install:
     image: node:24-bookworm-slim
     working_dir: /app
+    environment:
+      CI: "true"
+      PNPM_CONFIG_CONFIRM_MODULES_PURGE: "false"
     command: >
       sh -c "corepack enable &&
       corepack prepare pnpm@10.33.2 --activate &&
@@ -18,6 +21,8 @@ services:
       corepack prepare pnpm@10.33.2 --activate &&
       pnpm --filter @book-manager/backend dev"
     environment:
+      CI: "true"
+      PNPM_CONFIG_CONFIRM_MODULES_PURGE: "false"
       BACKEND_PORT: ${BACKEND_PORT:-3001}
       CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:3000}
       DATABASE_PATH: /data/book-manager.sqlite
@@ -39,6 +44,8 @@ services:
       corepack prepare pnpm@10.33.2 --activate &&
       pnpm --filter @book-manager/frontend dev --host 0.0.0.0"
     environment:
+      CI: "true"
+      PNPM_CONFIG_CONFIRM_MODULES_PURGE: "false"
       FRONTEND_PORT: ${FRONTEND_PORT:-3000}
       VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://localhost:3001}
       VITE_DEV_PROXY_TARGET: http://backend:3001


### PR DESCRIPTION
## Summary
- Add frontend API client types and calls for JSON export, import preview, and import execution
- Implement /data screen with JSON download, file upload, paste preview, and import execution
- Support Windows-copy-like conflict handling with all skip, all overwrite, and per-item choices
- Show preview summaries, validation errors, conflict details, and import results

## Verification
- mise run typecheck
- mise run test
- mise run build
- mise run lint
- docker compose --env-file .env.example config

Refs #13