### PR TITLE
Add CI workflow for workspace checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  workspace-checks:
+    name: Workspace checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup mise
+        uses: jdx/mise-action@v3
+        with:
+          install: true
+          cache: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: mise run install-ci
+
+      - name: Typecheck
+        run: mise run typecheck
+
+      - name: Test
+        run: mise run test
+
+      - name: Build
+        run: mise run build
+
+  docker-build:
+    name: Docker build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build Compose images
+        run: docker compose build

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ pnpm-debug.log*
 Thumbs.db
 .vscode/
 .idea/
+.codex

--- a/Docs/development.md
+++ b/Docs/development.md
@@ -32,6 +32,18 @@ mise run test
 
 通常の実装確認では、ホスト側で `pnpm install` が完了している状態なら `mise run test` を実行します。
 
+## CI
+
+GitHub ActionsではPull Requestと `main` へのpush時に、`mise.toml` で指定したNode.jsとpnpmを使って以下を実行します。
+
+- `mise run install-ci`
+- `mise run typecheck`
+- `mise run test`
+- `mise run build`
+- `docker compose build`
+
+CIでもDocker Composeはホスト側の `node_modules` をマウントせず、Dockerfile内で依存関係をインストールします。
+
 ## Docker Compose起動
 
 ```powershell

--- a/mise.toml
+++ b/mise.toml
@@ -6,6 +6,10 @@ pnpm = "10.33.2"
 description = "Install workspace dependencies"
 run = "pnpm install"
 
+[tasks.install-ci]
+description = "Install workspace dependencies with lockfile verification"
+run = "pnpm install --frozen-lockfile"
+
 [tasks.dev]
 description = "Run frontend and backend in development mode"
 run = "pnpm dev"


### PR DESCRIPTION
## Summary
- add GitHub Actions CI for pull requests and main pushes
- install Node.js and pnpm from mise.toml with jdx/mise-action
- run mise run install-ci/typecheck/test/build for workspace checks
- add a Docker Compose image build job
- document CI checks in Docs/development.md

Closes #51

## Verification
- mise run install-ci
- mise run typecheck
- mise run test
- mise run build

Note: local mise runs completed successfully. This sandbox emitted a mise cache write warning and pnpm engine warning, but the GitHub Actions workflow installs tools from mise.toml.